### PR TITLE
Added new tool: Text

### DIFF
--- a/packages/brushbox/src/components/textarea.tsx
+++ b/packages/brushbox/src/components/textarea.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { TTextAreaState } from './whiteboard';
+
+export type TTextarea = {
+  isTextVisible: boolean;
+  textAreaRef: React.RefObject<HTMLTextAreaElement>;
+  textareaState: TTextAreaState;
+  setTextareaState: (value: React.SetStateAction<TTextAreaState>) => void;
+  setIsTextVisible: (value: React.SetStateAction<boolean>) => void;
+  drawText: (val: string) => void;
+};
+
+export function Textarea({
+  textAreaRef,
+  textareaState,
+  setIsTextVisible,
+  setTextareaState,
+  drawText,
+}: Readonly<TTextarea>) {
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    if (textAreaRef.current) {
+      textAreaRef.current.style.height = '0px';
+      const scrollHeight = textAreaRef.current.scrollHeight;
+      textAreaRef.current.style.height = scrollHeight + 'px';
+
+      const span = document.createElement('span');
+      span.style.visibility = 'hidden';
+      span.style.position = 'absolute';
+      span.style.whiteSpace = 'pre';
+      const styles = window.getComputedStyle(textAreaRef.current);
+      span.style.font = styles.font;
+      document.body.appendChild(span);
+      span.textContent = value || ''; // Use 'x' as minimum width reference
+      const newWidth = Math.max(16, span.offsetWidth);
+      textAreaRef.current.style.width = newWidth + 'px';
+
+      document.body.removeChild(span);
+
+      setTextareaState({
+        ...textareaState,
+        height: scrollHeight,
+        width: newWidth,
+      });
+    }
+  }, [textAreaRef.current, value]);
+
+  return (
+    <textarea
+      rows={1}
+      ref={textAreaRef}
+      value={value}
+      onChange={(e) => {
+        setValue(e.target.value);
+      }}
+      onBlur={(e) => {
+        drawText(e.target.value);
+        setIsTextVisible(false);
+      }}
+      style={{
+        minWidth: '16px',
+        position: 'fixed',
+        top: `${textareaState.y}px`,
+        left: `${textareaState.x}px`,
+        zIndex: 200,
+        outline: 'none',
+        resize: 'none',
+        padding: '0px',
+        lineHeight: 1,
+        overflow: 'hidden',
+        whiteSpace: 'pre',
+        fontFamily: textareaState.fontFamily,
+        fontSize: textareaState.fontSize,
+        border: '1px solid black',
+        paddingLeft: '5px',
+        paddingRight: '5px',
+      }}
+    ></textarea>
+  );
+}

--- a/packages/brushbox/src/components/textarea.tsx
+++ b/packages/brushbox/src/components/textarea.tsx
@@ -72,7 +72,6 @@ export function Textarea({
         whiteSpace: 'pre',
         fontFamily: textareaState.fontFamily,
         fontSize: textareaState.fontSize,
-        border: '1px solid black',
         paddingLeft: '5px',
         paddingRight: '5px',
       }}

--- a/packages/brushbox/src/components/whiteboard.tsx
+++ b/packages/brushbox/src/components/whiteboard.tsx
@@ -7,20 +7,63 @@ import { RectangleTool } from '../tools/rectangleTool';
 import { LineTool } from '../tools/lineTool';
 import { FreehandTool } from '../tools/freedrawTool';
 import { TextTool } from '../tools/textTool';
+import { Textarea } from './textarea';
+import { Text } from '../shapes/text';
+
+export type TTextAreaState = {
+  text: string;
+  x: number;
+  y: number;
+  rotation: number;
+  fontSize: number;
+  fontFamily: string;
+  isVisible: boolean;
+  width: number;
+  height: number;
+};
 
 export function Brushbox() {
   const [isCanvasLoading, setIsCanvasLoading] = useState<boolean>(true);
   const [selectedTool, setSelectedTool] = useState<TSelectedTool>(
     TOOLS.SELECTION,
   );
+  const [isTextVisible, setIsTextVisible] = useState(false);
+  const [textareaState, setTextareaState] = useState<TTextAreaState>({
+    fontFamily: 'Aerial',
+    fontSize: 24,
+    width: 150,
+    height: 0,
+    x: 0,
+    y: 0,
+    isVisible: false,
+    rotation: 0,
+    text: '',
+  });
+
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const scene = useRef<Scene | null>(null);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(
     function () {
       if (canvasRef.current) {
         setIsCanvasLoading(false);
-        scene.current = new Scene(canvasRef.current);
+        scene.current = new Scene({
+          canvas: canvasRef.current,
+          selectedTool,
+          updateSelectedTool: function (val) {
+            setSelectedTool(val);
+          },
+          setTextareaVisibility: function (val) {
+            setIsTextVisible(val);
+          },
+          updateTextareaState: function (state: Partial<TTextAreaState>) {
+            setTextareaState((prevState) => ({
+              ...prevState,
+              ...state,
+            }));
+          },
+        });
         scene.current.setScale(window.devicePixelRatio);
         scene.current.initializeCanvas();
       }
@@ -62,6 +105,12 @@ export function Brushbox() {
     [selectedTool],
   );
 
+  useEffect(() => {
+    if (textAreaRef.current) {
+      textAreaRef.current.focus();
+    }
+  }, [isTextVisible]);
+
   return (
     <div className="brushbox-container">
       {isCanvasLoading && (
@@ -69,6 +118,33 @@ export function Brushbox() {
           <h1 className="">Loading Canvas...</h1>
         </div>
       )}
+      <div className="brushbox-textarea">
+        {isTextVisible && (
+          <Textarea
+            isTextVisible={isTextVisible}
+            textAreaRef={textAreaRef}
+            textareaState={textareaState}
+            setTextareaState={setTextareaState}
+            setIsTextVisible={setIsTextVisible}
+            drawText={function (val: string) {
+              if (!canvasRef.current) return;
+              const textShape = new Text({
+                text: val,
+                x: textareaState.x,
+                y: textareaState.y,
+                width: textareaState.width,
+                height: textareaState.height,
+              });
+
+              if (scene.current) {
+                scene.current.addElement(textShape);
+              }
+
+              textShape.draw(canvasRef.current);
+            }}
+          />
+        )}
+      </div>
       <div className="brushbox-wrapper">
         <canvas
           ref={canvasRef}

--- a/packages/brushbox/src/core/scene.ts
+++ b/packages/brushbox/src/core/scene.ts
@@ -1,18 +1,34 @@
 import { BaseShape } from "../shapes/baseShape";
 import { SelectTool } from "../tools/selectTool";
 import { BaseTool } from "../tools/baseTool";
+import { TSelectedTool } from "../components/toolbar";
+import { TTextAreaState } from "../components/whiteboard";
+
+type TSceneState = {
+  canvas: HTMLCanvasElement;
+  selectedTool: TSelectedTool;
+  updateSelectedTool: (val: TSelectedTool) => void;
+  setTextareaVisibility: (val: boolean) => void;
+  updateTextareaState: (state: Partial<TTextAreaState>) => void;
+}
 
 export class Scene {
   private readonly canvas: HTMLCanvasElement;
   private shapes: BaseShape[];
   private activeTool: BaseTool;
   private scale: number;
+  setTextareaVisibility: (val: boolean) => void;
+  updateSelectedTool: (val: TSelectedTool) => void;
+  updateTextareaState: (state: Partial<TTextAreaState>) => void;
 
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(sceneState: TSceneState) {
     this.shapes = [];
-    this.canvas = canvas;
+    this.canvas = sceneState.canvas;
     this.activeTool = new SelectTool(this);
     this.scale = 1;
+    this.setTextareaVisibility = sceneState.setTextareaVisibility;
+    this.updateSelectedTool = sceneState.updateSelectedTool;
+    this.updateTextareaState = sceneState.updateTextareaState;
   }
 
   initializeCanvas() {
@@ -107,5 +123,9 @@ export class Scene {
 
   getHitShapes(x: number, y: number) {
     return this.shapes.find(shape => shape.contain(x, y));
+  }
+
+  showTextField(fn: React.Dispatch<React.SetStateAction<boolean>>) {
+    fn(true);
   }
 }

--- a/packages/brushbox/src/shapes/text.ts
+++ b/packages/brushbox/src/shapes/text.ts
@@ -1,0 +1,121 @@
+import {
+  BaseShape,
+  TBaseShape,
+  TShapeBounds,
+  TShapeHandler,
+  TShapes
+} from "./baseShape";
+import { ROTATION_HANDLER_OFFSET, SHAPE_HANDLERS } from "../constants/shape-handlers";
+import { TMovingOffsets } from "../tools/selectTool";
+import { rotate } from "../utils/math";
+
+export type TText = Partial<TBaseShape> & {
+  type?: TShapes,
+  angle?: number,
+  x?: number,
+  y?: number,
+  width?: number,
+  height?: number,
+  fontSize?: number,
+  fontFamily?: string,
+  text: string
+}
+
+export class Text extends BaseShape {
+  type: TShapes;
+  angle: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text: string;
+  fontSize: number;
+  fontFamily: string;
+
+  constructor(options: TText) {
+    super(options);
+    this.type = options.type ?? "freedraw";
+    this.angle = options.angle ?? 0;
+    this.x = options.x ?? 0;
+    this.y = options.y ?? 0;
+    this.width = options.width ?? 30;
+    this.height = options.height ?? 30;
+    this.text = options.text;
+    this.fontFamily = options.fontFamily ?? "Aerial";
+    this.fontSize = options.fontSize ?? 24;
+  }
+
+  draw(canvas: HTMLCanvasElement): void {
+    const context = canvas.getContext("2d")!;
+    if (!context) return;
+
+    const cx = this.x + this.width / 2;
+    const cy = this.y + this.height / 2;
+
+    context.save();
+    context.beginPath();
+    context.translate(cx, cy);
+    context.rotate(this.angle);
+    context.textBaseline = "top";
+    context.font = `${this.fontSize}px ${this.fontFamily}`;
+
+    this.text.split("\n").forEach((chunk, index) => {
+      context.fillText(chunk, -this.width / 2, -this.height / 2 + (24 * index));
+    });
+
+    context.restore();
+  }
+
+  contain(x: number, y: number): boolean {
+    const minX = Math.min(this.x, this.x + this.width);
+    const maxX = Math.max(this.x, this.x + this.width);
+    const minY = Math.min(this.y, this.y + this.height);
+    const maxY = Math.max(this.y, this.y + this.height);
+
+    const [rotatedX, rotatedY] = rotate(x, y, (minX + maxX) / 2, (minY + maxY) / 2, -this.angle);
+
+    return rotatedX >= minX && rotatedX <= maxX && rotatedY >= minY && rotatedY <= maxY;
+  }
+
+  getBounds(): TShapeBounds {
+    const minX = Math.min(this.x, this.x + this.width);
+    const maxX = Math.max(this.x, this.x + this.width);
+    const minY = Math.min(this.y, this.y + this.height);
+    const maxY = Math.max(this.y, this.y + this.height);
+
+    return {
+      startX: minX,
+      startY: minY,
+      endX: maxX,
+      endY: maxY,
+    }
+  }
+
+  getHandlers(): TShapeHandler[] {
+    const bounds = this.getBounds();
+
+    return [
+      {
+        type: SHAPE_HANDLERS.ROTATION,
+        x: ((bounds.startX + bounds.endX) / 2),
+        y: bounds.startY - ROTATION_HANDLER_OFFSET,
+      }
+    ]
+  }
+
+  getRotationAngle(): number {
+    return this.angle;
+  }
+
+  translate({
+    offsetX,
+    offsetY,
+  }: TMovingOffsets): void {
+    this.x = offsetX;
+    this.y = offsetY;
+  }
+
+  rotate(angle: number): void {
+    this.angle = angle;
+  }
+}

--- a/packages/brushbox/src/tools/freedrawTool.ts
+++ b/packages/brushbox/src/tools/freedrawTool.ts
@@ -1,10 +1,10 @@
 import { Scene } from "../core/scene";
-import { Freedraw, FreeHandPoint } from "../shapes/freedraw";
+import { Freedraw, FreeDrawPoints } from "../shapes/freedraw";
 import { BaseTool } from "./baseTool";
 
 export class FreehandTool extends BaseTool {
   private isDrawing: boolean;
-  private points: FreeHandPoint[];
+  private points: FreeDrawPoints[];
 
   constructor(scene: Scene) {
     super(scene);

--- a/packages/brushbox/src/tools/selectTool.ts
+++ b/packages/brushbox/src/tools/selectTool.ts
@@ -11,6 +11,7 @@ import { Ellipse } from "../shapes/ellipse";
 import { Freedraw, FreeDrawPoints } from "../shapes/freedraw";
 import { Line } from "../shapes/line";
 import { Rectangle } from "../shapes/rectangle";
+import { Text } from "../shapes/text";
 import { rotate } from "../utils/math";
 import { BaseTool } from "./baseTool";
 
@@ -246,7 +247,9 @@ export class SelectTool extends BaseTool {
         const ROTATION_HANDLER = [0, (-height / 2) - 25];
 
         // draw handler
-        if (!(selectedShapes[0] instanceof Freedraw)) {
+        if (
+          !(selectedShapes[0] instanceof Freedraw) &&
+          !(selectedShapes[0] instanceof Text)) {
           RESIZE_HANDLER.forEach(([a, b]) => {
             context.save();
             context.beginPath();
@@ -492,7 +495,11 @@ export class SelectTool extends BaseTool {
             offsetY: lastY - shape.y,
             pointsOffsets
           });
-        } else if (shape instanceof Rectangle || shape instanceof Ellipse) {
+        } else if (
+          shape instanceof Rectangle ||
+          shape instanceof Ellipse ||
+          shape instanceof Text
+        ) {
           this.movingOffsets.set(shape.id, {
             offsetX: lastX - shape.x,
             offsetY: lastY - shape.y
@@ -918,7 +925,8 @@ export class SelectTool extends BaseTool {
             if (
               shape instanceof Rectangle ||
               shape instanceof Ellipse ||
-              shape instanceof Freedraw
+              shape instanceof Freedraw ||
+              shape instanceof Text
             ) {
               shape.rotate(angle);
             }

--- a/packages/brushbox/src/tools/textTool.ts
+++ b/packages/brushbox/src/tools/textTool.ts
@@ -1,0 +1,24 @@
+import { Scene } from "../core/scene";
+import { BaseTool } from "./baseTool";
+
+export class TextTool extends BaseTool {
+  constructor(scene: Scene) {
+    super(scene);
+  }
+
+  handleMouseDown(event: React.MouseEvent<HTMLCanvasElement, MouseEvent>) {
+    const handleMouseUp = (event: MouseEvent) => {
+      window.removeEventListener("pointerup", handleMouseUp);
+
+      const { clientX, clientY } = event;
+      this.scene.updateTextareaState({
+        x: clientX,
+        y: clientY,
+      });
+      this.scene.setTextareaVisibility(true);
+      this.scene.updateSelectedTool("selection");
+    }
+
+    window.addEventListener('pointerup', handleMouseUp);
+  }
+}


### PR DESCRIPTION
## Issue

fixes #5 

## Description

The drawing app now has a new `TEXT` tool. Users can write text anywhere on the canvas.
Users can select the text and move it around. Also, the text can be rotated

## Visual changes

![Screenshot 2024-11-20 010146](https://github.com/user-attachments/assets/bbcd1ec8-e562-464c-86d7-44502286e272)

![Screenshot 2024-11-20 010221](https://github.com/user-attachments/assets/613fc84b-f41d-4b48-afe3-56e7621c2ac1)

![Screenshot 2024-11-20 010240](https://github.com/user-attachments/assets/b6838ee0-bba1-4341-9f62-97f13cb12c1d)
